### PR TITLE
libchromeos-ui: Fix LIBCHROME_VER location

### DIFF
--- a/meta-chromeos-base/recipes-chromeos/libchromeos-ui/libchromeos-ui_0.0.2.bb
+++ b/meta-chromeos-base/recipes-chromeos/libchromeos-ui/libchromeos-ui_0.0.2.bb
@@ -60,7 +60,7 @@ do_install() {
         ln -sf ${fn}.${SO_VERSION} ${D}${libdir}/${fn}
     done
 
-    LIBCHROME_VER=$(cat ${WORKDIR}/src/platform/libchrome/BASE_VER)
+    LIBCHROME_VER=$(cat ${WORKDIR}/src/platform2/libchrome/BASE_VER)
 
     install -d ${D}${libdir}/pkgconfig
     sed -e "s/@BSLOT@/${LIBCHROME_VER}/g" ${S}/libchromeos-ui.pc.in > ${B}/lib/libchromeos-ui.pc


### PR DESCRIPTION
Use platform2 instead of platform.

TEST=Check "bitbake chromeos-image-base" goes through. The error was: cat:
$BUILD_PATH/tmp/work/core2-64-chromeos-linux/libchromeos-ui/0.0.1-r1924/src/platform/libchrome/BASE_VER: No such file or directory

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>